### PR TITLE
Updates due to updating to karaf version 4.3.4

### DIFF
--- a/blaze-core/pom.xml
+++ b/blaze-core/pom.xml
@@ -16,12 +16,6 @@
   <dependencies>
     <dependency>
       <groupId>com.kodality.blaze</groupId>
-      <artifactId>blaze-osgi</artifactId>
-      <version>1.0-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.kodality.blaze</groupId>
       <artifactId>fhir-structures</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/etc/conf/users.properties
+++ b/etc/conf/users.properties
@@ -1,0 +1,33 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# This file contains the users, groups, and roles.
+# Each line has to be of the format:
+#
+# USER=PASSWORD,ROLE1,ROLE2,...
+# USER=PASSWORD,_g_:GROUP,...
+# _g_\:GROUP=ROLE1,ROLE2,...
+#
+# All users, groups, and roles entered in this file are available after Karaf startup
+# and modifiable via the JAAS command group. These users reside in a JAAS domain
+# with the name "karaf".
+#
+karaf = karaf,_g_:admingroup
+_g_\:admingroup = group,admin,manager,viewer,systembundles,ssh

--- a/etc/docker/blaze/Dockerfile
+++ b/etc/docker/blaze/Dockerfile
@@ -1,4 +1,4 @@
-FROM kodality/karaf:4.3.0
+FROM kodality/karaf:4.3.4
 
 COPY etc /opt/karaf/etc
 

--- a/pg-jdbc/pom.xml
+++ b/pg-jdbc/pom.xml
@@ -27,12 +27,12 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>5.2.9.RELEASE</version>
+      <version>5.3.12</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
-      <version>5.2.9.RELEASE</version>
+      <version>5.3.12</version>
     </dependency>
     <dependency>
       <groupId>com.kodality.blaze</groupId>


### PR DESCRIPTION
- Removed dependency that is not available.
- Upgraded spring dependencies
- Added users.properties file with default user uncommented to overwrite default one
- Use karaf 4.3.4